### PR TITLE
bug if levels of factor column are not already in 'alpha' order

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -3,13 +3,12 @@ preprocess <- function(oh, x) UseMethod("preprocess")
 
 #' @export
 preprocess.column_info_factor <- function(oh, x, ...) {
-
   x <- factor(as.character(x))
   if (any(is.na(oh$levels))) {
     x <- addNA(x)
   }
 
-  levels(x) <- oh$levels
+  levels(x) <- oh$levels[match(levels(x), oh$levels)] # weird re-ordering can happen on levels(x)
   x
 }
 


### PR DESCRIPTION
Bug in reordering of factor levels if they are not already in "alphabetical" order e.g. `c(1, 6, 12)` gets changed to `c(1, 12, 6)`.

Reprex:
```
library(onehot)

test <- data.frame(
  fct = factor(c(1, 6, 12, 999, NA), levels = c(1, 6, 12, 999, NA))
)
test$fct_chr <- as.character(test$fct)
test$fct_chr_fct <- factor(test$fct_chr)
test2 <- test[1:2, ] # future new data

encoder <- onehot(test, add_NA_factors = TRUE)
test_onehot <- predict(encoder, test)
View(cbind(test, test_onehot))

test2_onehot <- predict(encoder, test2) # reuse encoder on new data
View(cbind(test2, test2_onehot))
all(colnames(test_onehot) == colnames(test2_onehot))
```